### PR TITLE
Clear archive flag from hidden files

### DIFF
--- a/7zBackup.ps1
+++ b/7zBackup.ps1
@@ -833,7 +833,7 @@ Function PostArchiving {
 		If(Check-CTRLCRequest -eq $True) { break; }
 		$percentCompleted = ( $i / ($ArchivedItemsCount - 1) * 100 )
 		Write-Progress -Activity  "Performing post archive operations" -Status "Please wait ..." -CurrentOperation ("{0} successfully archived files" -f $OperationType)  -PercentComplete $percentCompleted
-		$item = Get-Item -LiteralPath (Join-Path $BkRootDir $BkCompressDetailItems[$i].File)
+		$item = Get-Item -LiteralPath (Join-Path $BkRootDir $BkCompressDetailItems[$i].File) -Force
 		if($? -and $item) {
 			If($BkType -eq "move") {
 				$item | ? { !$_.PSIsContainer } | Remove-Item -Force | Out-Null

--- a/7zBackup.ps1
+++ b/7zBackup.ps1
@@ -1083,6 +1083,8 @@ Function Remove-Junction  {
 Function Remove-RootDir {
 	param([string]$rootPath = $(throw "You must provide a path to the directory")) 
 	
+	Write-Debug "About to remove root-dir"
+	
 	If (Test-Path -Path $rootPath -PathType Container) {
 		Set-Variable -Name "junctionsRemoved" -Value $True -Scope Private | Out-Null
 		Get-ChildItem -Path $rootPath | ? { $_.Attributes -band 1024 } | ForEach-Object {
@@ -2404,6 +2406,7 @@ If(($Counters.FilesSelected -lt 1) -or (Check-CTRLCRequest)) {
 		$oProcessStartInfo.UseShellExecute = $false
 		$oProcessStartInfo.CreateNoWindow = $true
 		$oProcessStartInfo.Arguments = ($Bk7ZipArgs -join " ")
+		Write-Verbose "7z arguments:  $($Bk7ZipArgs -join ' ')"
 		$oProcess = New-Object -Typename System.Diagnostics.Process
 		$oProcess.StartInfo = $oProcessStartInfo
 		


### PR DESCRIPTION
When doing a Full or Incremental backup, the Archive flag wasn't being removed from files that had the Hidden flag set. Adding the `-Force` switch to the `Get-Item` command that drives this resolves it.

I've also left in 2 debugging statements that have proven very useful. Since they're `Write-Verbose` and `Write-Debug`, they'll only be effective when someone specifically runs the program with the appropriate switches, so won't clutter up normal execution. 

Let me know if you really don't want these debugging statements in and I'll remove them, but I think they'll be useful :wink: